### PR TITLE
Add Japanese labels and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,132 @@
-# salseforce_inquiry
+# Salesforce Inquiry Management
+
+This repository contains a sample Salesforce DX project that demonstrates basic Aura components for managing customer inquiries using the standard **Case** object. The components implement features such as a new case form, list view, detail editing, and a simple Kanban board.
+
+## Components
+
+- **NewCaseForm** - Create a new Case record using Lightning Data Service.
+- **CaseListView** - Display a table of cases.
+- **CaseDetail** - Edit Case fields inline on the detail page.
+- **CaseKanban** - Visualize cases grouped by status.
+
+The project is structured as a standard Salesforce DX project under `force-app/main/default`.
+All component labels and picklist options are displayed in **Japanese** to provide a localized user experience.
+
+## Setup
+
+### Salesforce DX Configuration
+
+Follow these steps to set up a scratch org and deploy the source using the [Salesforce CLI](https://developer.salesforce.com/tools/sfdxcli). The commands below use the `sf` CLI.
+
+1. **Authenticate with your Dev Hub** (only required once):
+   ```bash
+   sf org login web --set-default-dev-hub --alias DevHub
+   ```
+   This command opens a browser window where you log in to the org that you want
+   to use as your Dev Hub.
+2. **Create a scratch org** using the project configuration provided in
+   `config/project-scratch-def.json`:
+   ```bash
+   sf org create scratch --definition-file config/project-scratch-def.json --set-default --alias ScratchOrg
+   ```
+   The `--set-default` flag sets this org as the default, and `--alias` assigns it the alias
+   `ScratchOrg` for easy reference.
+   If the command fails because of an invalid feature, edit `config/project-scratch-def.json`
+   and adjust the `features` array (which is empty by default) to include only
+   valid feature names.
+3. **Push the source to the scratch org**:
+   ```bash
+   sf project deploy start --source-dir force-app --target-org ScratchOrg
+   ```
+4. **Assign permissions** if your project includes permission sets:
+   ```bash
+   sf org assign permset --name Inquiry_App --target-org ScratchOrg
+   ```
+5. **Open the scratch org** to verify the components:
+   ```bash
+   sf org open --target-org ScratchOrg
+   ```
+
+To deploy to a non-scratch org, replace `force:source:push` with
+`force:source:deploy` (or the `sf project deploy start` command) and specify the target username or alias:
+
+```bash
+sf project deploy start --source-dir force-app --target-org MySandbox
+```
+
+### Object Configuration
+
+1. **Case Fields**
+   - Ensure the standard fields `Subject`, `Status`, `Priority`, `Origin`, `Type`, `AccountId`, and `ContactId` are on the page layout.
+   - Create a custom field `SLA_Due_Date__c` (Date) to track due dates.
+2. **Picklist Values**
+   - `Status`: create Japanese values such as *新規*, *進行中*, *解決済み*, *完了*.
+   - `Priority`: use values *高*, *中*, *低*.
+3. **Record Types** (optional)
+   - Create record types for different inquiry types such as *Product Bug*, *How-to Question*, etc.
+4. **Page Layout**
+   - Add the custom fields to the Case page layout.
+   - Use Lightning App Builder to place the Aura components (NewCaseForm, CaseListView, CaseDetail, CaseKanban) on your pages.
+5. **Assignment and Notifications**
+   - Set up assignment rules or Flows to automatically assign new cases.
+   - Configure email or in-app notifications for status changes and approaching SLA dates.
+
+### Deployment Steps
+
+After configuring your org, deploy the source. Replace `<your-org>` with the alias
+or username of the org you want to deploy to (run `sf org list` to see available
+orgs):
+
+```bash
+sf project deploy start --source-dir force-app --target-org <your-org>
+```
+
+Once deployed, open your Lightning app and verify that the components appear on the pages configured above.
+
+### Post-Deployment Testing
+
+After deployment, verify that each component behaves as expected in the target org:
+
+1. **Create a Test Case**
+   - Navigate to the page containing the `NewCaseForm` component.
+   - Submit a new case and confirm that a success message appears.
+   - Check that the record is created with the correct values.
+2. **Validate List and Detail Views**
+   - Open the `CaseListView` and ensure that the newly created case appears in the table with the correct fields.
+   - Click a case to open the `CaseDetail` component and edit a field using inline editing. Save and confirm the toast notification.
+3. **Check the Kanban Board**
+   - Navigate to the `CaseKanban` component and verify that cases are grouped by status. Drag a card to a different column and refresh the list to confirm the status update.
+4. **Run Apex Tests (if any)**
+   - Execute `sf apex run test --target-org <your-org>` to run automated tests included in the project. Review the results for failures.
+
+Document the results of these checks so that you can repeat them when deploying to additional environments.
+
+### Migrating to Production
+
+When you are ready to move the system to a production org, follow one of these approaches:
+
+1. **Change Set Promotion**
+   - In your sandbox, create an outbound change set that includes the metadata under `force-app/main/default`.
+   - Upload the change set to production and validate the deployment. Fix any issues reported during validation, then deploy.
+2. **Unlocked Package or Metadata API**
+   - Create an unlocked package using the Salesforce CLI or package.xml with the Metadata API. Install the package in a staging sandbox first to confirm that all components deploy correctly before installing in production.
+
+Always test in a full or partial copy sandbox before deploying to production to ensure that data-specific issues do not cause errors.
+
+### When Salesforce DX Is Unavailable
+
+If the Salesforce CLI is not an option, you can deploy the metadata using one of the following methods:
+
+1. **Change Sets**
+   - From Setup in your source org, create an outbound change set.
+   - Add the components from `force-app/main/default` and upload the change set to your target org.
+   - In the target org, open the inbound change set and deploy it.
+   - This method is completely web-based but is manual and harder to automate.
+2. **Metadata API / Ant Migration Tool**
+   - Download the [Force.com Migration Tool](https://developer.salesforce.com/docs/atlas.en-us.develop.meta/develop/develop_ant.htm).
+   - Configure `build.xml` to point to your org and run:
+     ```bash
+     ant deployCode
+     ```
+   - This provides a scripted deployment option without relying on Salesforce DX.
+

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,0 +1,10 @@
+{
+  "orgName": "Inquiry Management Scratch Org",
+  "edition": "Developer",
+  "features": [],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    }
+  }
+}

--- a/force-app/main/default/aura/CaseDetail/CaseDetail.cmp
+++ b/force-app/main/default/aura/CaseDetail/CaseDetail.cmp
@@ -1,0 +1,25 @@
+<aura:component implements="force:hasRecordId,flexipage:availableForRecordHome" access="global">
+    <lightning:recordEditForm recordId="{!v.recordId}" objectApiName="Case" onsuccess="{!c.handleSuccess}">
+        <lightning:messages />
+        <div class="slds-grid slds-wrap">
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Subject"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Status"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Priority"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Origin"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Type"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:button variant="brand" type="submit" label="保存"/>
+            </div>
+        </div>
+    </lightning:recordEditForm>
+</aura:component>

--- a/force-app/main/default/aura/CaseDetail/CaseDetail.cmp-meta.xml
+++ b/force-app/main/default/aura/CaseDetail/CaseDetail.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <description>CaseDetail component</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/CaseDetail/CaseDetailController.js
+++ b/force-app/main/default/aura/CaseDetail/CaseDetailController.js
@@ -1,0 +1,5 @@
+({
+    handleSuccess : function(component, event, helper) {
+        helper.showToast('保存完了', 'ケースが更新されました', 'success');
+    }
+})

--- a/force-app/main/default/aura/CaseDetail/CaseDetailHelper.js
+++ b/force-app/main/default/aura/CaseDetail/CaseDetailHelper.js
@@ -1,0 +1,13 @@
+({
+    showToast : function(title, message, type) {
+        var toastEvent = $A.get("e.force:showToast");
+        if (toastEvent) {
+            toastEvent.setParams({
+                "title": title,
+                "message": message,
+                "type": type
+            });
+            toastEvent.fire();
+        }
+    }
+})

--- a/force-app/main/default/aura/CaseKanban/CaseKanban.cmp
+++ b/force-app/main/default/aura/CaseKanban/CaseKanban.cmp
@@ -1,0 +1,15 @@
+<aura:component controller="CaseKanbanController" implements="flexipage:availableForAllPageTypes" access="global">
+    <aura:attribute name="groups" type="List" />
+    <aura:handler name="init" value="{!this}" action="{!c.init}" />
+    <div class="slds-grid slds-wrap">
+        <aura:iteration items="{!v.groups}" var="group">
+            <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-4">
+                <lightning:card title="{!group.status}">
+                    <aura:iteration items="{!group.records}" var="caseRec">
+                        <div class="kanban-card">{!caseRec.Subject}</div>
+                    </aura:iteration>
+                </lightning:card>
+            </div>
+        </aura:iteration>
+    </div>
+</aura:component>

--- a/force-app/main/default/aura/CaseKanban/CaseKanban.cmp-meta.xml
+++ b/force-app/main/default/aura/CaseKanban/CaseKanban.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <description>CaseKanban component</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/CaseKanban/CaseKanban.css
+++ b/force-app/main/default/aura/CaseKanban/CaseKanban.css
@@ -1,0 +1,6 @@
+.THIS .kanban-card {
+    background: #f3f2f2;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    border-radius: 0.25rem;
+}

--- a/force-app/main/default/aura/CaseKanban/CaseKanbanController.js
+++ b/force-app/main/default/aura/CaseKanban/CaseKanbanController.js
@@ -1,0 +1,5 @@
+({
+    init : function(component, event, helper) {
+        helper.loadCases(component);
+    }
+})

--- a/force-app/main/default/aura/CaseKanban/CaseKanbanHelper.js
+++ b/force-app/main/default/aura/CaseKanban/CaseKanbanHelper.js
@@ -1,0 +1,21 @@
+({
+    loadCases : function(component) {
+        var action = component.get("c.getCases");
+        action.setCallback(this, function(response) {
+            if (response.getState() === "SUCCESS") {
+                var cases = response.getReturnValue();
+                var groups = [];
+                var map = {};
+                cases.forEach(function(c) {
+                    if (!map[c.Status]) {
+                        map[c.Status] = {status: c.Status, records: []};
+                        groups.push(map[c.Status]);
+                    }
+                    map[c.Status].records.push(c);
+                });
+                component.set("v.groups", groups);
+            }
+        });
+        $A.enqueueAction(action);
+    }
+})

--- a/force-app/main/default/aura/CaseListView/CaseListView.cmp
+++ b/force-app/main/default/aura/CaseListView/CaseListView.cmp
@@ -1,0 +1,11 @@
+<aura:component controller="CaseListViewController" implements="flexipage:availableForAllPageTypes" access="global">
+    <aura:attribute name="cases" type="Case[]" />
+    <aura:attribute name="columns" type="List" />
+    <aura:handler name="init" value="{!this}" action="{!c.init}" />
+    <lightning:card title="問合せ一覧">
+        <lightning:dataTable data="{!v.cases}"
+                             columns="{!v.columns}"
+                             keyField="Id"
+                             hideCheckboxColumn="true"/>
+    </lightning:card>
+</aura:component>

--- a/force-app/main/default/aura/CaseListView/CaseListView.cmp-meta.xml
+++ b/force-app/main/default/aura/CaseListView/CaseListView.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <description>CaseListView component</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/CaseListView/CaseListViewController.js
+++ b/force-app/main/default/aura/CaseListView/CaseListViewController.js
@@ -1,0 +1,11 @@
+({
+    init : function(component, event, helper) {
+        component.set('v.columns', [
+            {label: '件名', fieldName: 'Subject', type: 'text'},
+            {label: '状況', fieldName: 'Status', type: 'text'},
+            {label: '優先度', fieldName: 'Priority', type: 'text'},
+            {label: '所有者', fieldName: 'OwnerName', type: 'text'}
+        ]);
+        helper.loadCases(component);
+    }
+})

--- a/force-app/main/default/aura/CaseListView/CaseListViewHelper.js
+++ b/force-app/main/default/aura/CaseListView/CaseListViewHelper.js
@@ -1,0 +1,12 @@
+({
+    loadCases : function(component) {
+        var action = component.get("c.getCases");
+        action.setCallback(this, function(response) {
+            var state = response.getState();
+            if (state === "SUCCESS") {
+                component.set("v.cases", response.getReturnValue());
+            }
+        });
+        $A.enqueueAction(action);
+    }
+})

--- a/force-app/main/default/aura/NewCaseForm/NewCaseForm.cmp
+++ b/force-app/main/default/aura/NewCaseForm/NewCaseForm.cmp
@@ -1,0 +1,36 @@
+<aura:component implements="flexipage:availableForAllPageTypes" access="global">
+    <lightning:recordEditForm aura:id="caseForm"
+                              objectApiName="Case"
+                              onsuccess="{!c.handleSuccess}">
+        <lightning:messages />
+        <div class="slds-grid slds-wrap">
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Subject" required="true"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Status"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Priority"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Origin"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="Type"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="AccountId"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:inputField fieldName="ContactId"/>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:fileUpload label="ファイルを添付" multiple="true" recordId="{!v.recordId}" />
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning:button variant="brand" type="submit" label="ケースを作成"/>
+            </div>
+        </div>
+    </lightning:recordEditForm>
+</aura:component>

--- a/force-app/main/default/aura/NewCaseForm/NewCaseForm.cmp-meta.xml
+++ b/force-app/main/default/aura/NewCaseForm/NewCaseForm.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <description>NewCaseForm component</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/NewCaseForm/NewCaseFormController.js
+++ b/force-app/main/default/aura/NewCaseForm/NewCaseFormController.js
@@ -1,0 +1,6 @@
+({
+    handleSuccess : function(component, event, helper) {
+        var payload = event.getParams().response;
+        helper.showToast('成功', 'ケースが作成されました: ' + payload.id, 'success');
+    }
+})

--- a/force-app/main/default/aura/NewCaseForm/NewCaseFormHelper.js
+++ b/force-app/main/default/aura/NewCaseForm/NewCaseFormHelper.js
@@ -1,0 +1,13 @@
+({
+    showToast : function(title, message, type) {
+        var toastEvent = $A.get("e.force:showToast");
+        if (toastEvent) {
+            toastEvent.setParams({
+                "title": title,
+                "message": message,
+                "type": type
+            });
+            toastEvent.fire();
+        }
+    }
+})

--- a/force-app/main/default/classes/CaseKanbanController.cls
+++ b/force-app/main/default/classes/CaseKanbanController.cls
@@ -1,0 +1,6 @@
+public with sharing class CaseKanbanController {
+    @AuraEnabled(cacheable=true)
+    public static List<Case> getCases() {
+        return [SELECT Id, Subject, Status FROM Case LIMIT 200];
+    }
+}

--- a/force-app/main/default/classes/CaseKanbanController.cls-meta.xml
+++ b/force-app/main/default/classes/CaseKanbanController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CaseListViewController.cls
+++ b/force-app/main/default/classes/CaseListViewController.cls
@@ -1,0 +1,27 @@
+public with sharing class CaseListViewController {
+    @AuraEnabled(cacheable=true)
+    public static List<CaseWrapper> getCases() {
+        List<Case> cases = [SELECT Id, Subject, Status, Priority, Owner.Name FROM Case LIMIT 50];
+        List<CaseWrapper> results = new List<CaseWrapper>();
+        for (Case c : cases) {
+            results.add(new CaseWrapper(c));
+        }
+        return results;
+    }
+
+    public class CaseWrapper {
+        @AuraEnabled public Id Id;
+        @AuraEnabled public String Subject;
+        @AuraEnabled public String Status;
+        @AuraEnabled public String Priority;
+        @AuraEnabled public String OwnerName;
+
+        public CaseWrapper(Case c) {
+            Id = c.Id;
+            Subject = c.Subject;
+            Status = c.Status;
+            Priority = c.Priority;
+            OwnerName = c.Owner.Name;
+        }
+    }
+}

--- a/force-app/main/default/classes/CaseListViewController.cls-meta.xml
+++ b/force-app/main/default/classes/CaseListViewController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/permissionsets/Inquiry_App.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Inquiry_App.permissionset-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Inquiry App</label>
+    <hasActivationRequired>false</hasActivationRequired>
+    <objectPermissions>
+        <object>Case</object>
+        <allowCreate>true</allowCreate>
+        <allowRead>true</allowRead>
+        <allowEdit>true</allowEdit>
+        <allowDelete>true</allowDelete>
+        <viewAllRecords>false</viewAllRecords>
+        <modifyAllRecords>false</modifyAllRecords>
+    </objectPermissions>
+    <classAccesses>
+        <apexClass>CaseKanbanController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>CaseListViewController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+</PermissionSet>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,0 +1,11 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "58.0"
+}


### PR DESCRIPTION
## Summary
- translate component labels to Japanese
- document Japanese picklist values
- mention Japanese localization in README

## Testing
- `npm test` *(fails: package.json missing)*
- `sfdx force:source:deploy --checkonly -p force-app` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684915c9df18832eac4efbaa096b30e5